### PR TITLE
adding static_keynames support

### DIFF
--- a/chex/_src/dataclass.py
+++ b/chex/_src/dataclass.py
@@ -282,7 +282,7 @@ def _flatten_with_path(dcls):
     # Store the static keys separately.
     if (dcls.static_keynames is not None and
         k.name in dcls.static_keynames):
-      static_keynames.append(k)
+      static_keynames.append(k.name)
       static_keyvals.append(v)
     else:
       path.append((k, v))


### PR DESCRIPTION
Added support for static_keynames which lets you specify key names to ignore for jax transformations  #64
, all tests seem to be passing I've attached the test log (bash test.sh > test_out.txt)
[test_out.txt](https://github.com/google-deepmind/chex/files/13761093/test_out.txt)

I'd love to have a cleaner way to get the static_keynames in the flatten func if anyone has ideas, this way there's no indication to users that static_keynames is something placed in there by chex, but calling it _static_keynames set off the tests for private access.

To demonstrate a use case with this I can dataclassify this:

```
@chex.dataclass(frozen=True)
class Foo:
    name: str
    data: jnp.ndarray

def noise(key, foo):
    rng, key = jax.random.split(key)
    noise = jax.random.normal(rng, foo.data.shape)
    return foo.data + noise
```

but when I try to JIT the noise function it will crash because the name in the dataclass is a str which is not a valid jax type.

If I do this instead:
```
@chex.dataclass(frozen=True, static_keynames=["name"])
class Foo:
    name: str
    data: jnp.ndarray

def noise(key, foo):
    rng, key = jax.random.split(key)
    noise = jax.random.normal(rng, foo.data.shape)
    return foo.data + noise
```
then it won't crash since it will make the name field static
now I can jit it just fine (but if I try to use a static field in a jax transformed function in a non-static way then it will crash)