### PR TITLE
fix: update abstract type hints to use collections.abc instead of typ…

### DIFF
--- a/chex/_src/asserts.py
+++ b/chex/_src/asserts.py
@@ -19,7 +19,8 @@ import collections.abc
 import functools
 import inspect
 import traceback
-from typing import Any, Callable, List, Optional, Sequence, Set, Union, cast
+from collections.abc import Sequence
+from typing import Any, Callable, List, Optional, Set, Union, cast
 import unittest
 from unittest import mock
 

--- a/chex/_src/asserts_chexify_test.py
+++ b/chex/_src/asserts_chexify_test.py
@@ -19,7 +19,8 @@ import re
 import sys
 import threading
 import time
-from typing import Any, Optional, Sequence, Type
+from collections.abc import Sequence
+from typing import Any, Optional, Type
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/chex/_src/asserts_internal.py
+++ b/chex/_src/asserts_internal.py
@@ -24,12 +24,12 @@ Instead, consider opening an issue on GitHub and describing your use case.
 
 import collections
 import collections.abc
-from collections.abc import Hashable
+from collections.abc import Hashable, Sequence
 import functools
 import re
 import threading
 import traceback
-from typing import Any, Sequence, Union, Callable, List, Optional, Set, Tuple, Type
+from typing import Any, Union, Callable, List, Optional, Set, Tuple, Type
 
 from absl import logging
 from chex._src import pytypes

--- a/chex/_src/dataclass_test.py
+++ b/chex/_src/dataclass_test.py
@@ -20,7 +20,8 @@ import copy
 import dataclasses
 import pickle
 import sys
-from typing import Any, Generic, Mapping, TypeVar
+from collections.abc import Mapping
+from typing import Any, Generic, TypeVar
 import unittest
 
 from absl.testing import absltest

--- a/chex/_src/dimensions.py
+++ b/chex/_src/dimensions.py
@@ -14,10 +14,10 @@
 # ==============================================================================
 """Utilities to hold expected dimension sizes."""
 
-from collections.abc import Sized
+from collections.abc import Collection, Sized
 import math
 import re
-from typing import Any, Collection, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 
 Shape = Tuple[Optional[int], ...]

--- a/chex/_src/fake.py
+++ b/chex/_src/fake.py
@@ -25,7 +25,8 @@ import functools
 import inspect
 import os
 import re
-from typing import Any, Callable, Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Any, Callable, Optional, Union
 from unittest import mock
 from absl import flags
 import jax

--- a/chex/_src/pytypes.py
+++ b/chex/_src/pytypes.py
@@ -14,7 +14,8 @@
 # ==============================================================================
 """Type definitions to use for type annotations."""
 
-from typing import Any, Iterable, Mapping, Sequence, Union
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Union
 
 import jax
 import numpy as np

--- a/chex/_src/restrict_backends.py
+++ b/chex/_src/restrict_backends.py
@@ -29,7 +29,8 @@ at the end of the first iteration, the system can detect any overlooked cases.
 """
 import contextlib
 import functools
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 # pylint: disable=g-import-not-at-top
 try:

--- a/chex/_src/variants.py
+++ b/chex/_src/variants.py
@@ -18,7 +18,8 @@ import enum
 import functools
 import inspect
 import itertools
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 import unittest
 
 from absl import flags

--- a/chex/_src/warnings.py
+++ b/chex/_src/warnings.py
@@ -15,7 +15,8 @@
 """Utilities to emit warnings."""
 
 import functools
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 import warnings
 
 


### PR DESCRIPTION
Updates imports of abstract base classes (Iterable, Mapping, Sequence, etc.) to use collections.abc instead of typing, following PEP 585 deprecation guidelines. This ensures compatibility with future Python versions (3.14+).

#361 